### PR TITLE
update to preciseID active/active server

### DIFF
--- a/lib/experian/precise_id/client.rb
+++ b/lib/experian/precise_id/client.rb
@@ -13,7 +13,7 @@ module Experian
       end
 
       def precise_uri
-        "https://#{Experian.test_mode ? 'dm-sgw1' : 'pid-sgw'}.experian.com/fraudsolutions/xmlgateway/preciseid"
+        "https://#{Experian.test_mode ? 'dm-sgw1' : 'pid-sgw.secure'}.experian.com/fraudsolutions/xmlgateway/preciseid"
       end
 
       def verify_identity(options = {})

--- a/lib/experian/precise_id/client.rb
+++ b/lib/experian/precise_id/client.rb
@@ -13,7 +13,7 @@ module Experian
       end
 
       def precise_uri
-        "https://#{Experian.test_mode ? 'dm-' : ''}sgw1.experian.com/fraudsolutions/xmlgateway/preciseid"
+        "https://#{Experian.test_mode ? 'dm-sgw1' : 'pid-sgw'}.experian.com/fraudsolutions/xmlgateway/preciseid"
       end
 
       def verify_identity(options = {})

--- a/lib/experian/version.rb
+++ b/lib/experian/version.rb
@@ -1,5 +1,5 @@
 module Experian
   ORIG_VERSION = "0.1.7"
   # Blinker Version
-  VERSION = "0.1.7.5"
+  VERSION = "0.1.7.6"
 end


### PR DESCRIPTION
https://blinker.leankit.com/Boards/View/337281094/473210740

experian test server is already migrated to a/a, only change the URL for production calls

bump gem version